### PR TITLE
Skip guild summons

### DIFF
--- a/bin/create_profile
+++ b/bin/create_profile
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(cd $(dirname $0) && pwd)
+PROFILES_DIR=${SCRIPT_DIR}/../profiles
+
+if [ -z $1 ]; then
+  echo "No characther name specified.  Usage: $0 [character name] [guild]"
+  exit 1
+else
+  PROFILE_PATH=${PROFILES_DIR}/$1.tin
+  cp ${PROFILES_DIR}/profile_example.tin ${PROFILE_PATH}
+fi
+
+if [ -z $2 ]; then
+  echo "No guild specified.  Usage: $0 [character name] [guild]"
+  rm ${PROFILE_PATH}
+  exit 1
+else
+  sed -i.bak "s/put your guild here/$2/" ${PROFILE_PATH}
+  if [ $? == 0 ]; then
+    rm ${PROFILE_PATH}.bak
+  fi
+fi
+

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -3,4 +3,7 @@ Profiles start the tintin session.  To use this framework you need a profile tha
 - matches your character name and ends in '.tin'
 - has a '#var guild {<your guild here>};' defined line in the file
 
-See 'profile_example.tin' for an example.  You can copy this file and rename it to your character name.
+See 'profile_example.tin' for an example.
+
+You can copy this file and rename it to your character name, or use the `bin/create_profile` utility.
+Usage: `bin/create_profile [your character] [your guild]

--- a/tin/default/actions/combat.tin
+++ b/tin/default/actions/combat.tin
@@ -74,3 +74,7 @@
 #action {^You plummet, and SLAM into the ground!$} {
   #if {$map[current_room] ==  12492} {run lettuce};
 }
+
+#action {^The guacamole coating %1 finally oozes off.} {
+  !wear all;
+}

--- a/tin/guilds/mages/aliases/hpbar.tin
+++ b/tin/guilds/mages/aliases/hpbar.tin
@@ -26,7 +26,7 @@
 
 #alias stepper_check {
   #if {"$stepper" == "on"} {
-    #if {$corpses == 0 || $sp < 750} {
+    #if {($corpses == 0 && $spell_taps < 2) || $sp < 750} {
       stepper off;
     };
   };

--- a/tin/stepper/actions.tin
+++ b/tin/stepper/actions.tin
@@ -24,15 +24,19 @@
 
 #action {^[M] %1} {
   set_under_attack %1;
-  #script {monster_name} {./bin/monster_name "%1"};
+  #local guild_summon_status {@is_guild_summon{%1}};
 
-  #local monster_name $monster_name[1];
-  #format {monster_name} {%l} {$monster_name};
+  #if {"$guild_summon_status" == "false"} {
+    #script {monster_name} {./bin/monster_name "%1"};
 
-  #list {seen_monsters} {find} {$monster_name} {index_if_seen};
+    #local monster_name $monster_name[1];
+    #format {monster_name} {%l} {$monster_name};
 
-  #if {$index_if_seen == 0} {
-    #list {seen_monsters} {add} {$monster_name};
+    #list {seen_monsters} {find} {$monster_name} {index_if_seen};
+
+    #if {$index_if_seen == 0} {
+      #list {seen_monsters} {add} {$monster_name};
+    };
   };
 }
 

--- a/tin/stepper/aliases.tin
+++ b/tin/stepper/aliases.tin
@@ -103,7 +103,7 @@
     #var stepper on;
     #unvar step_dir;
     #unvar entered_from;
-    !glance;
+    #delay {1} {!glance};
   } {
     #showme <170>Disabling stepping. 'stepper on' to re-enable.;
     tracker off;

--- a/tin/stepper/aliases.tin
+++ b/tin/stepper/aliases.tin
@@ -73,13 +73,13 @@
 
 #alias remove_blacklisted_monsters {
   #foreach $seen_monsters[%*] {seen_monster} {
-    #foreach $monster_blacklist[%*] {monster} {
-      #regexp {$seen_monster} {$monster} {remove_seen_monster $seen_monster};
+    #foreach $monster_blacklist[%*] {blacklisted_monster} {
+      #regexp {$seen_monster} {$blacklisted_monster} {remove_seen_monster $seen_monster};
     };
   };
 
   #unvar seen_monster;
-  #unvar monster;
+  #unvar blacklisted_monster;
 }
 
 #alias set_entered_from {

--- a/tin/stepper/blacklist.txt
+++ b/tin/stepper/blacklist.txt
@@ -1,6 +1,3 @@
-(%+ golem) [tank]
-a tame little shrew
-a %+ of %+ broodling
 an old dwarven smith
 arundin
 bryant
@@ -33,9 +30,4 @@ the grand elemental
 the grand monk
 valerie, the lobby ambassador
 village wisewoman
-%+ storm servant
-%+ broodling
 %+ ferryman
-%+ the manshi
-%+ the valithyn
-%+ the grimare

--- a/tin/stepper/functions.tin
+++ b/tin/stepper/functions.tin
@@ -5,6 +5,26 @@
   #return $cardinal_exits[$random_index];
 }
 
+#function is_guild_summon {
+  #local monster %0;
+  #local guild_summons;
+  #local guild_summon;
+  #var guild_summon_status false;
+
+  #script {guild_summons} {
+    while read line; do echo "$line"; done < ./tin/stepper/guild_summons.txt
+  };
+
+  #foreach $guild_summons[%*] {guild_summon} {
+    #regexp {$monster} {%i$guild_summon} {#replace guild_summon_status {false} {true}};
+    #if {"$guild_summon_status" == "true"} {#break};
+  };
+
+  #var result $guild_summon_status;
+  #unvar guild_summon_status;
+  #return $result;
+}
+
 #function transform_mob {
   #local transform_string $monster_transforms[%0];
 

--- a/tin/stepper/guild_summons.txt
+++ b/tin/stepper/guild_summons.txt
@@ -1,0 +1,8 @@
+(%w golem)
+a tame little shrew
+a %+ of %+ broodling
+%+ storm servant
+%+ broodling
+%+ the manshi
+%+ the valithyn
+%+ the grimare


### PR DESCRIPTION
#### What's new
- added create new profile utility to create profiles
- adding action to re-wear when guacamole in death taco makes you stop wearing eq
- added a "skip" of guild summons separate from blacklist (context below)

A blacklisted mob has to match a monster name.  That monster name is generated by stripping off brackets, parens, etc. to make it just a string that can be attacked.  Turns out with guild summons it doesn't work so well.  Example: mage golems
Ted (straw Golem) [tank] (100%)

When this gets filtered through `bin/monster_name` you get 'Ted'.  Rather than blacklist all the names a golem could get i want to blacklist '(%w Golem)'.

Rather than even try to redo the parsing I added a bypass to the tracker/stepper.  If a monster to be targeted matches a guild summon (no filtering done on monster name happens at this point), it will be skipped and not added to seen monsters list.

There might be a TODO here which is just do this with all mobs I want to skip: skip them outright and don't parse/format their strings (again, TODO).